### PR TITLE
Solution for "-Wunused-variable" in gcc

### DIFF
--- a/include/qpp.h
+++ b/include/qpp.h
@@ -35,8 +35,10 @@
 #define QPP_H_
 
 // silence bogus warning -Wunused-variable for singletons
-#if (__GNUC__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
+#if (__GNUC__ && !__clang__)
+#define _QPP_UNUSED_  __attribute__ ((unused))
+#else 
+#define _QPP_UNUSED_ 
 #endif
 
 #include <algorithm>
@@ -115,28 +117,28 @@ namespace qpp
 *
 * Additional initializations/cleanups, see the class qpp::Init
 */
-static const Init& init = Init::get_instance();
+static const Init& init _QPP_UNUSED_= Init::get_instance();
 
 /**
 * \brief qpp::Codes const Singleton
 *
 * Initializes the codes, see the class qpp::Codes
 */
-static const Codes& codes = Codes::get_instance();
+static const Codes& codes _QPP_UNUSED_= Codes::get_instance();
 
 /**
 * \brief qpp::Gates const Singleton
 *
 * Initializes the gates, see the class qpp::Gates
 */
-static const Gates& gt = Gates::get_instance();
+static const Gates& gt _QPP_UNUSED_= Gates::get_instance();
 
 /**
 * \brief qpp::States const Singleton
 *
 * Initializes the states, see the class qpp::States
 */
-static const States& st = States::get_instance();
+static const States& st _QPP_UNUSED_= States::get_instance();
 
 /**
 * \brief qpp::RandomDevices Singleton
@@ -147,9 +149,9 @@ static const States& st = States::get_instance();
 * std::mt19937 and possible data races
 */
 #ifdef _NO_THREAD_LOCAL
-static RandomDevices& rdevs = RandomDevices::get_instance();
+static RandomDevices& rdevs _QPP_UNUSED_= RandomDevices::get_instance();
 #else
-thread_local static RandomDevices& rdevs =
+thread_local static RandomDevices& rdevs _QPP_UNUSED_=
         RandomDevices::get_thread_local_instance();
 #endif // _NO_THREAD_LOCAL
 


### PR DESCRIPTION
Hi,
I have a simple solution for  bogus warnings "-Wunused-variable for Singletons" in gcc. It will not silent all "-Wunused-variable" warnings but only for singletons that has been initialized in qpp.h file. I am attaching my version of qpp.h file. Hope that you will find it useful. 

P.S. similar trick can be used for lambda functions too.