### PR TITLE
Improved error handling & recovery in QASM frontend

### DIFF
--- a/include/qasm/ast.h
+++ b/include/qasm/ast.h
@@ -227,7 +227,7 @@ class Context {
                 return it->second.get();
         }
 
-        std::cerr << "At (" << loc << "): Undeclared identifier " << id << "\n";
+        std::cerr << loc << ": Undeclared identifier " << id << "\n";
         throw exception::Undeclared("qpp::qasm::Context::lookup()");
     }
 
@@ -584,7 +584,7 @@ class Varinfo : public IDisplay {
         auto reg = dynamic_cast<const Register*>(ctx.lookup(id_, loc_));
 
         if (reg == nullptr || reg->quantum_) {
-            std::cerr << "At (" << loc_ << "): Identifier " << id_
+            std::cerr << loc_ << ": Identifier " << id_
                       << " does not refer to a bit register\n";
             throw exception::SemanticError("qpp::qasm::Varinfo::as_creg()");
         }
@@ -597,7 +597,7 @@ class Varinfo : public IDisplay {
 
             // check register size
             if ((idx) offset_ >= reg->indices_.size()) {
-                std::cerr << "At (" << loc_ << "): Index out of bounds\n";
+                std::cerr << loc_ << ": Index out of bounds\n";
                 throw exception::SemanticError("qpp::qasm::Varinfo::as_qreg()");
             }
 
@@ -624,7 +624,7 @@ class Varinfo : public IDisplay {
                 auto reg = dynamic_cast<const Register*>(tmp);
                 // check register type
                 if (reg == nullptr || !reg->quantum_) {
-                    std::cerr << "At (" << loc_ << "): Identifier " << id_
+                    std::cerr << loc_ << ": Identifier " << id_
                               << " does not refer to a qubit register\n";
                     throw exception::SemanticError(
                         "qpp::qasm::Varinfo::as_qreg()");
@@ -638,14 +638,14 @@ class Varinfo : public IDisplay {
 
             // check register type
             if (reg == nullptr || !reg->quantum_) {
-                std::cerr << "At (" << loc_ << "): Identifier " << id_
+                std::cerr << loc_ << ": Identifier " << id_
                           << " does not refer to a qubit register\n";
                 throw exception::SemanticError("qpp::qasm::Varinfo::as_qreg()");
             }
 
             // check register size
             if ((idx) offset_ >= reg->indices_.size()) {
-                std::cerr << "At (" << loc_ << "): Index out of bounds\n";
+                std::cerr << loc_ << ": Index out of bounds\n";
                 throw exception::SemanticError("qpp::qasm::Varinfo::as_qreg()");
             }
 
@@ -916,7 +916,7 @@ class IfStatement final : public Statement {
 
         // check register type
         if (creg == nullptr || creg->quantum_) {
-            std::cerr << "At (" << loc_ << "): Identifier " << id_
+            std::cerr << loc_ << ": Identifier " << id_
                       << " does not refer to a classic register\n";
             throw exception::SemanticError(
                 "qpp::qasm::IfStatement::evaluate()");
@@ -1077,8 +1077,7 @@ class CNOTGate final : public Gate {
                 }
             }
         } else {
-            std::cerr << "At (" << loc_
-                      << "): Registers have different lengths\n";
+            std::cerr << loc_ << ": Registers have different lengths\n";
             throw exception::SemanticError("qpp::qasm::CNOTGate::evaluate()");
         }
     }
@@ -1123,8 +1122,7 @@ class BarrierGate final : public Gate {
                 if (mapping_size == 1) {
                     mapping_size = tmp.size();
                 } else if (mapping_size != tmp.size()) {
-                    std::cerr << "At (" << loc_
-                              << "): Registers have different lengths\n";
+                    std::cerr << loc_ << ": Registers have different lengths\n";
                     throw exception::SemanticError(
                         "qpp::qasm::BarrierGate::evaluate()");
                 }
@@ -1177,7 +1175,7 @@ class DeclaredGate final : public Gate {
 
         // check gate type
         if (gate == nullptr) {
-            std::cerr << "At (" << loc_ << "): Identifier " << id_
+            std::cerr << loc_ << ": Identifier " << id_
                       << " does not refer to a gate declaration\n";
             throw exception::SemanticError(
                 "qpp::qasm::DeclaredGate::evaluate()");
@@ -1185,13 +1183,13 @@ class DeclaredGate final : public Gate {
 
         // check argument lengths
         if (c_args_.size() != gate->c_params_.size()) {
-            std::cerr << "At (" << loc_ << "): " << id_ << " expects "
+            std::cerr << loc_ << ": " << id_ << " expects "
                       << gate->c_params_.size();
             std::cerr << " classic arguments, got " << c_args_.size() << "\n";
             throw exception::SemanticError(
                 "qpp::qasm::DeclaredGate::evaluate()");
         } else if (q_args_.size() != gate->q_params_.size()) {
-            std::cerr << "At (" << loc_ << "): " << id_ << " expects "
+            std::cerr << loc_ << ": " << id_ << " expects "
                       << gate->q_params_.size();
             std::cerr << " quantum arguments, got " << q_args_.size() << "\n";
             throw exception::SemanticError(
@@ -1215,8 +1213,7 @@ class DeclaredGate final : public Gate {
                 if (mapping_size == 1) {
                     mapping_size = q_args[i].size();
                 } else if (mapping_size != q_args[i].size()) {
-                    std::cerr << "At (" << loc_
-                              << "): Registers have different lengths\n";
+                    std::cerr << loc_ << ": Registers have different lengths\n";
                     throw exception::SemanticError(
                         "qpp::qasm::DeclaredGate::evaluate()");
                 }
@@ -1418,7 +1415,7 @@ class VarExpr final : public Expr {
         auto val = dynamic_cast<const Number*>(ctx.lookup(value_, loc_));
 
         if (val == nullptr) {
-            std::cerr << "At (" << loc_ << "): Identifier " << value_;
+            std::cerr << loc_ << ": Identifier " << value_;
             std::cerr << " does not refer to a classical parameter\n";
             throw exception::ParseError("qpp::qasm::VarExpr::evaluate()");
         }

--- a/include/qasm/lexer.h
+++ b/include/qasm/lexer.h
@@ -60,7 +60,7 @@ class Lexer {
      * \param fname The name of the file associated with buffer (optional)
      */
     Lexer(std::shared_ptr<std::istream> buffer, const std::string& fname = "")
-        : loc_(fname, 0, 0), buf_(buffer) {}
+        : loc_(fname, 1, 1), buf_(buffer) {}
 
     /**
      * \brief Lex and return the next token

--- a/include/qasm/preprocessor.h
+++ b/include/qasm/preprocessor.h
@@ -141,8 +141,7 @@ class Preprocessor {
      */
     Token next_token() {
         if (current_lexer_ == nullptr) {
-            std::cerr << "No target to lex.\n";
-            return {};
+          return Token(Location(), Token::Kind::eof, "");
         }
         auto token = current_lexer_->next_token();
         if (token.is(Token::Kind::kw_include)) {

--- a/include/qasm/token.h
+++ b/include/qasm/token.h
@@ -41,8 +41,8 @@ namespace qasm {
  */
 class Location : public IDisplay {
     std::string fname_ = ""; ///< name of the containing file
-    idx line_ = 0;           ///< line number
-    idx column_ = 0;         ///< column number
+    idx line_ = 1;           ///< line number
+    idx column_ = 1;         ///< column number
 
   public:
     /**


### PR DESCRIPTION
Better grouping and suppressing of related parse errors, and better recovery into a valid parse state once an error is encountered. In particular, for files with multiple syntax errors this new update should be able to more accurately identify the errors and no longer report errors in the otherwise correct parts of the source code.

Bug fixes:
  - fixes infinite loop bug in certain parser combinators
  - fixes off-by-one error for line and column numbers